### PR TITLE
Move active Python podcasts to top of the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@
 
 > Podcasts related to Python Programming Language
 
-- [Import This](https://www.kennethreitz.org/import-this/) - A Python Podcast for Humans.
 - [podcast.__init__](https://www.podcastinit.com/) - The Podcast About Python and the People Who Make It Great.
 - [Python Bytes](https://pythonbytes.fm/) - Python headlines delivered directly to your earbuds.
 - [Talk Python To Me](https://talkpython.fm/episodes/all) - A podcast on Python and related technologies.
+- [Import This](https://www.kennethreitz.org/import-this/) - A Python Podcast for Humans.
 
 ## Ruby
 

--- a/awesome-podcasts.json
+++ b/awesome-podcasts.json
@@ -599,11 +599,6 @@
     "category": "Python",
     "pods": [
       {
-        "desc": "A Python Podcast for Humans.",
-        "name": "Import This",
-        "url": "https://www.kennethreitz.org/import-this/"
-      },
-      {
         "desc": "The Podcast About Python and the People Who Make It Great.",
         "name": "podcast.__init__",
         "url": "https://www.podcastinit.com/"
@@ -617,6 +612,11 @@
         "desc": "A podcast on Python and related technologies.",
         "name": "Talk Python To Me",
         "url": "https://talkpython.fm/episodes/all"
+      },
+      {
+        "desc": "A Python Podcast for Humans.",
+        "name": "Import This",
+        "url": "https://www.kennethreitz.org/import-this/"
       }
     ],
     "subtitle": "Podcasts related to Python Programming Language"


### PR DESCRIPTION
This PR moves the active Python podcasts to top of the list. Import this was top. But has only had one episode in the last 6 months, that 2 months ago. The other three a vibrant and active.